### PR TITLE
feat: Add key "dataExchange" to `db.subscribe` response

### DIFF
--- a/manager.asyncapi.yaml
+++ b/manager.asyncapi.yaml
@@ -481,6 +481,8 @@ channels:
           properties:
             dataServerAddress:
               $ref: "#/components/schemas/dataServerAddress"
+            dataExchange:
+              $ref: "#/components/schemas/dataExchange"
             dataQueue:
               $ref: "#/components/schemas/dataQueue"
               description: "Metrics to be saved in the DB arrive on this queue"


### PR DESCRIPTION
This reflects the changes of the manager [here](https://github.com/metricq/metricq-manager/commit/5ae9878528e4b642eb4c55b767df18169ee1ad1f).